### PR TITLE
Update components.js

### DIFF
--- a/app/js/adapter/owf7Participant/modules/components.js
+++ b/app/js/adapter/owf7Participant/modules/components.js
@@ -37,8 +37,10 @@ ozpIwc.owf7.participantModules.Components = (function(){
      */
     Components.prototype.onLaunchWidget=function(sender,msg,rpc) {
         msg=JSON.parse(msg);
+        // Allow launching by the widget's universal name or by the guid
+        var launchKey = msg.universalName || ms.guid;
         // ignore title, titleRegex, and launchOnlyIfClosed
-        this.systemApi.launch("/application/" + msg.guid,{
+        this.systemApi.launch("/application/" + launchKey,{
             contentType: "text/plain",
             entity: msg.data
         }).then(function(reply) {


### PR DESCRIPTION
OWF7 allowed launching widgets by their universal names. This change brings that functionality to the adapter for OZP.